### PR TITLE
User can mark their posted Ad as sold #166176826 ch2

### DIFF
--- a/app/controller/carController.js
+++ b/app/controller/carController.js
@@ -72,8 +72,6 @@ const CarController = {
             };
         }
 
-
-        // const c = new Car()
         const car = Car.postCar(data);
         this.status = 201;
         return {
@@ -99,6 +97,42 @@ const CarController = {
             "status": this.status,
             "data": cars
         };
+    },
+
+    /**
+     * 
+     * @param {uuid} id
+     * @returns {oblect} update car status
+     */
+    updateStatus(id, data) {
+        if (data.status === undefined && data.status !== 0) {
+            this.status = 400;
+            return {
+                "status": this.status,
+                "error": "status is required in the request"
+            }
+        }
+        if (Validator.isValidStatus(data.status) !== "valid") {
+            this.status = 417;
+            return {
+                "status": this.status,
+                "error": Validator.isValidStatus(data.status)
+            }
+
+        }
+        if (!Car.viewSpecificCar(id)) {
+            this.status = 404;
+            return {
+                "status": this.status,
+                "error": `Car with id ${id} not found`
+            }
+        }
+
+        this.status = 200;
+        return {
+            "status": this.status,
+            "data": Car.updateStatus(id, data)
+        }
     }
 }
 

--- a/app/controller/orderController.js
+++ b/app/controller/orderController.js
@@ -45,7 +45,7 @@ const OrderController = {
     /**
      * 
      * @param {uuid} id
-     * @returns {oblect} update order object
+     * @returns {object} update order price
      */
     updatePrice(id, data) {
         if (data.offered_price === undefined && data.offered_price !== 0) {

--- a/app/model/cars.js
+++ b/app/model/cars.js
@@ -22,10 +22,10 @@ class Car {
             {
                 id: "b8aa4d11-baa4-4d6b",
                 createdOn: moment().format('llll'),
-                state: "available",
+                state: "used",
+                status: "available",
                 price: 20000,
-                manufacturer: "used",
-                statuscturer: "WolksWagon",
+                manufacturer: "VolksWagon",
                 model: "2016 Amarok",
                 type: "Pickup Truck",
                 photo: "https://malaba6.github.io/Auto-Mart/img/volkswagen.jpg"
@@ -70,6 +70,27 @@ class Car {
      */
     viewAllCars() {
         return this.cars;
+    }
+
+    /**
+     * 
+     * @params {uuid} id
+     * @returns {object} car object
+     */
+    updateStatus(id, data) {
+        let car = this.viewSpecificCar(id);
+        car.status = data.status;
+        return {
+            id: car.id,
+            createdOn: car.createdOn,
+            state: car.state,
+            status: car.status,
+            price: car.price,
+            manufacturer: car.manufacturer,
+            model: car.model,
+            type: car.type,
+            photo: data.photo
+        }
     }
 
 }

--- a/app/validation/validation.js
+++ b/app/validation/validation.js
@@ -85,6 +85,16 @@ const Validator = {
             return `Couldn't find image ${photo}`;
         }
         return "valid";
+    },
+
+    isValidStatus(status) {
+        if (typeof status !== "string" || status.length === 0) {
+            return "Status must be a string of characters not null";
+        }
+        if (status !== "sold" && status !== "available") {
+            return "Status must be either available or sold";
+        }
+        return "valid";
     }
 }
 

--- a/app/view/views.js
+++ b/app/view/views.js
@@ -38,4 +38,10 @@ route.patch('/api/v1/order/:id/price', (req, res) => {
     const patchedOrder = OrderController.updatePrice(req.params.id, req.body);
     return res.status(OrderController.status).send(patchedOrder);
 });
+
+route.patch('/api/v1/car/:id/status', (req, res) => {
+    const sold = CarController.updateStatus(req.params.id, req.body);
+    return res.status(CarController.status).send(sold);
+});
+
 export default route;


### PR DESCRIPTION
**What does this PR do?**
- Creates the endpoint for the user to mark their posted Ad as `sold`

**Description of the task to be completed**
The user should include the following field in the request : 
- status

**Relevant PT Stories:**
[User can mark their posted Ad as sold](https://www.pivotaltracker.com/story/show/166176826)


**How should this manually be tasted?**
In POSTMAN:

`First post a car sale ad `  > method `POST`
https://http://localhost:3000/api/v1/car
{
  "state": "new",
  "model" : "Corolla S",
  "manufacturer": "Toyota",
  "type": "Car",
  "price": 10000,
  "photo": "https://malaba6.github.io/Auto-Mart/img/ford.jpg"
}
`Then mark a posted Ad as sold `  > method `PATCH`
https://http://localhost:3000/api/v1/car/521247a0-8a90-47ef-a3fa-6d082348a501/status
{
	"status": "sold"
}

**Screenshots:**
![ch2-mark-sold](https://user-images.githubusercontent.com/50101879/58558983-66667380-8222-11e9-80fd-9b163270b5fd.PNG)





