### PR TITLE
User can fetch unsold cars with specific manufacturer #166367586 ch2

### DIFF
--- a/app/controller/carController.js
+++ b/app/controller/carController.js
@@ -106,6 +106,7 @@ const CarController = {
             const cars = Car.viewUnsoldCars(query.status);
             this.status = 200;
             if (cars.length === 0) {
+                this.status = 404;
                 return {
                     "status": this.status,
                     "message": "Oh oh! No cars Posted here yet!"
@@ -154,6 +155,7 @@ const CarController = {
             const cars = Car.viewCarsWithinRange(query);
             this.status = 200;
             if (cars.length === 0) {
+                this.status = 404;
                 return {
                     "status": this.status,
                     "message": "Oh oh! No cars within that range"
@@ -187,6 +189,7 @@ const CarController = {
             const cars = Car.viewCarsWithState(query);
             this.status = 200;
             if (cars.length === 0) {
+                this.status = 404;
                 return {
                     "status": this.status,
                     "message": `Oh oh! No ${query.state} cars here yet`
@@ -198,13 +201,77 @@ const CarController = {
             }
         }
 
-        if (data.status && data.manufacturer && length == 2) {
-            console.log("Status and manufaturer");
+        // Check if status and manufacturer are included in the query
+        if (query.status && query.manufacturer && length == 2) {
+            if (Validator.isValidStatusQuery(query.status) !== "valid") {
+                this.status = 404;
+                return {
+                    "status": this.status,
+                    "error": Validator.isValidStatusQuery(query.status)
+                }
+            }
+
+            if (Validator.isValidManufacturer(query.manufacturer) !== "valid") {
+                this.status = 417;
+                return {
+                    "status": this.status,
+                    "error": Validator.isValidManufacturer(query.manufacturer)
+                }
+            }
+
+            const cars = Car.viewCarsWithManufacturer(query);
+            this.status = 200;
+            if (cars.length === 0) {
+                this.status = 404;
+                return {
+                    "status": this.status,
+                    "message": `Oh oh! No ${query.manufacturer} cars here yet`
+                }
+            }
+            return {
+                "status": this.status,
+                "data": cars
+            }
         }
-        if (data.status && data.body_type && length == 2) {
-            console.log("Status and body_type");
+
+        // Check if status and type are included the query param
+        if (query.status && query.type && length == 2) {
+            if (Validator.isValidStatusQuery(query.status) !== "valid") {
+                this.status = 404;
+                return {
+                    "status": this.status,
+                    "error": Validator.isValidStatusQuery(query.status)
+                }
+            }
+
+            if (Validator.isValidType(query.type) !== "valid") {
+                this.status = 417;
+                return {
+                    "status": this.status,
+                    "error": Validator.isValidType(query.type)
+                }
+            }
+
+            const cars = Car.viewCarsWithType(query);
+            this.status = 200;
+            if (cars.length === 0) {
+                this.status = 404;
+                return {
+                    "status": this.status,
+                    "message": `Oh oh! No ${query.type} cars here yet`
+                }
+            }
+            return {
+                "status": this.status,
+                "data": cars
+            }
         }
-        console.log("Invalid query. ")
+
+        this.status = 400;
+        return {
+            "status": this.status,
+            "error": "Invalid query. We could not find what you are looking for"
+        }
 
     },
 

--- a/app/model/cars.js
+++ b/app/model/cars.js
@@ -104,6 +104,26 @@ class Car {
 
     /**
      * 
+     * @param {object} object
+     * @returns {object} unsold cars with specific manufacturer
+     */
+    viewCarsWithManufacturer(query) {
+        return this.cars.filter(car => car.status === query.status &&
+            car.manufacturer.toLowerCase() === query.manufacturer.toLowerCase());
+    }
+
+    /**
+     * 
+     * @param {object} object
+     * @returns {object} unsold cars with specific type
+     */
+    viewCarsWithType(query) {
+        return this.cars.filter(car => car.status === query.status &&
+            car.type.toLowerCase().includes(query.type.toLowerCase()));
+    }
+
+    /**
+     * 
      * @params {uuid} id
      * @returns {object} update car status
      */


### PR DESCRIPTION
**What does this PR do?**
- Creates the endpoint for the user can fetch all unsold cars with a specific manufacturer 
- Creates the endpoint for the user can fetch all unsold cars with a specific  type

**Description of the task to be completed**
The user must provide the following query parameters to visit this endpoint:
- status: available
- manufacturer: XXValue
For body type, the user must provide the following
- status: available
- type: XXValue

**Relevant PT Stories:**
[User can fetch unsold cars with a specific manufacturer or type](https://www.pivotaltracker.com/story/show/166367586)


**How should this manually be tasted?**
In POSTMAN:

`To view cars with specific manufacturer `  > method `GET`
https://http://localhost:3000/api/v1/car?status=available&manufacturer=XXValue
`To view cars with specific type `  > method `GET`
https://http://localhost:3000/api/v1/car?status=available&type=XXValue


**Screenshots:**
![ch2-get-manuf](https://user-images.githubusercontent.com/50101879/58669167-889fe480-833b-11e9-8a84-cd4c68033b14.PNG)
